### PR TITLE
Fixing truncate problem

### DIFF
--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -590,6 +590,11 @@ class Text
             }
             $truncate = mb_substr($truncate, 0, $spacepos);
         }
+        // If truncate still empty, then we don't need to count ellipsis in the cut.
+        if(empty($truncate)){
+                
+           $truncate = mb_substr($text, 0, $length);
+        }
         $truncate .= $ellipsis;
 
         if ($html) {


### PR DESCRIPTION
When passing a length that is equal to the length of ellipsis, the returned string will be the ellipsis value only, this would happen either passing TRUE of FALSE for the exact option.
e.g.

String::truncate('Hello', 3);  // would return ...